### PR TITLE
fix vendor file path not being clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,5 @@
-[![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/codingyu.laravel-goto-view.svg)](https://marketplace.visualstudio.com/items?itemName=codingyu.laravel-goto-view) [![Installs](https://vsmarketplacebadge.apphb.com/installs/codingyu.laravel-goto-view.svg)](https://marketplace.visualstudio.com/items?itemName=codingyu.laravel-goto-view)
+# laravel-goto-lang
 
-# How to use
-![How to use](images/use.gif)
-
-# Features
-- 👨‍💻
-- Support for custom path
-- Support for [nwidart/laravel-modules](https://packagist.org/packages/nwidart/laravel-modules)
-
-# Settings
-## `laravel_goto_view.folders`
-Search according to the configured path
-```
-"laravel_goto_view.folders": {
-    "default" : "/resources/views",
-    "theme_xxx": "/resources/views/theme_xxx"
-}
-```
-## `laravel_goto_view.extensions`
-Search views according to the configured extensions
-```
-"laravel_goto_view.extensions": {
-    "default" : ".blade.php",
-    "inky": ".inky.php"
-}
-```
-## `laravel_goto_view.quickJump`
-Use 'Ctrl' or 'Alt' + click, jump to the first match file.
-## `laravel_goto_view.folderTip`
-Display the path name of the configuration
+### TODO
+- [ ] show config value on hover
+- [ ] scroll/peek directly to the hovered config key

--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
-# laravel-goto-lang
+[![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/codingyu.laravel-goto-view.svg)](https://marketplace.visualstudio.com/items?itemName=codingyu.laravel-goto-view) [![Installs](https://vsmarketplacebadge.apphb.com/installs/codingyu.laravel-goto-view.svg)](https://marketplace.visualstudio.com/items?itemName=codingyu.laravel-goto-view)
 
-### TODO
-- [ ] show config value on hover
-- [ ] scroll/peek directly to the hovered config key
+# How to use
+![How to use](images/use.gif)
+
+# Features
+- 👨‍💻
+- Support for custom path
+- Support for [nwidart/laravel-modules](https://packagist.org/packages/nwidart/laravel-modules)
+
+# Settings
+## `laravel_goto_view.folders`
+Search according to the configured path
+```
+"laravel_goto_view.folders": {
+    "default" : "/resources/views",
+    "theme_xxx": "/resources/views/theme_xxx"
+}
+```
+## `laravel_goto_view.extensions`
+Search views according to the configured extensions
+```
+"laravel_goto_view.extensions": {
+    "default" : ".blade.php",
+    "inky": ".inky.php"
+}
+```
+## `laravel_goto_view.quickJump`
+Use 'Ctrl' or 'Alt' + click, jump to the first match file.
+## `laravel_goto_view.folderTip`
+Display the path name of the configuration

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "laravel-goto-lang",
-    "displayName": "Laravel goto lang",
-    "description": "Quick jump to lang",
-    "version": "0.0.1",
-    "publisher": "ctf0",
+    "name": "laravel-goto-view",
+    "displayName": "Laravel goto view",
+    "description": "Quick jump to view",
+    "version": "1.2.5",
+    "publisher": "codingyu",
     "engines": {
         "vscode": "^1.19.0"
     },
+    "icon": "images/icon.jpg",
     "bugs": {
-        "url": "https://github.com/ctf0/laravel-goto-lang/issues"
+        "url": "https://github.com/codingyu/laravel-goto-view/issues"
     },
-    "homepage": "https://github.com/ctf0/laravel-goto-lang/blob/master/README.md",
+    "homepage": "https://github.com/codingyu/laravel-goto-view/blob/master/README.md",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ctf0/laravel-goto-lang.git"
+        "url": "https://github.com/codingyu/laravel-goto-view.git"
     },
-    "icon": "images/logo.png",
     "categories": [
         "Other"
     ],
@@ -29,12 +29,23 @@
     "contributes": {
         "configuration": {
             "type": "object",
-            "title": "Laravel goto lang configuration",
+            "title": "Laravel goto view configuration",
             "properties": {
-                "laravel_goto_lang.folders": {
+                "laravel_goto_view.quickJump": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Use 'Ctrl' or 'Alt' + click"
+                },
+                "laravel_goto_view.folderTip": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Display path name"
+                },
+                "laravel_goto_view.folders": {
                     "type": "object",
                     "default": {
-                        "default": "/resources/lang/en"
+                        "default": "/resources/views"
+                        "vendor": "/resources/views/vendor"
                     },
                     "items": {
                         "type": "string"
@@ -43,7 +54,7 @@
                     "uniqueItems": true,
                     "description": "Multiple folders"
                 },
-                "laravel_goto_lang.extensions": {
+                "laravel_goto_view.extensions": {
                     "type": "object",
                     "default": {
                         "default": ".blade.php"

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "laravel-goto-view",
-    "displayName": "Laravel goto view",
-    "description": "Quick jump to view",
-    "version": "1.2.5",
-    "publisher": "codingyu",
+    "name": "laravel-goto-lang",
+    "displayName": "Laravel goto lang",
+    "description": "Quick jump to lang",
+    "version": "0.0.1",
+    "publisher": "ctf0",
     "engines": {
         "vscode": "^1.19.0"
     },
-    "icon": "images/icon.jpg",
     "bugs": {
-        "url": "https://github.com/codingyu/laravel-goto-view/issues"
+        "url": "https://github.com/ctf0/laravel-goto-lang/issues"
     },
-    "homepage": "https://github.com/codingyu/laravel-goto-view/blob/master/README.md",
+    "homepage": "https://github.com/ctf0/laravel-goto-lang/blob/master/README.md",
     "repository": {
         "type": "git",
-        "url": "https://github.com/codingyu/laravel-goto-view.git"
+        "url": "https://github.com/ctf0/laravel-goto-lang.git"
     },
+    "icon": "images/logo.png",
     "categories": [
         "Other"
     ],
@@ -29,23 +29,12 @@
     "contributes": {
         "configuration": {
             "type": "object",
-            "title": "Laravel goto view configuration",
+            "title": "Laravel goto lang configuration",
             "properties": {
-                "laravel_goto_view.quickJump": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Use 'Ctrl' or 'Alt' + click"
-                },
-                "laravel_goto_view.folderTip": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Display path name"
-                },
-                "laravel_goto_view.folders": {
+                "laravel_goto_lang.folders": {
                     "type": "object",
                     "default": {
-                        "default": "/resources/views",
-                        "vendor": "/resources/views/vendor"
+                        "default": "/resources/lang/en"
                     },
                     "items": {
                         "type": "string"
@@ -54,7 +43,7 @@
                     "uniqueItems": true,
                     "description": "Multiple folders"
                 },
-                "laravel_goto_view.extensions": {
+                "laravel_goto_lang.extensions": {
                     "type": "object",
                     "default": {
                         "default": ".blade.php"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
                 "laravel_goto_view.folders": {
                     "type": "object",
                     "default": {
-                        "default": "/resources/views"
+                        "default": "/resources/views",
+                        "vendor": "/resources/views/vendor"
                     },
                     "items": {
                         "type": "string"

--- a/src/providers/hoverProvider.ts
+++ b/src/providers/hoverProvider.ts
@@ -5,21 +5,20 @@ import * as util from '../util';
 
 export class HoverProvider implements vscode.HoverProvider {
     provideHover(doc: vscode.TextDocument, pos: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
-        let reg = /(?<=view\(|@include\(|@extends\(|@component\()(['"])[^'"]*\1/;
-        let config = vscode.workspace.getConfiguration('laravel_goto_view');
+        let reg = /(?<=trans\(|__\(|@lang\()(['"])[^'"]*\1/;
         let linkRange = doc.getWordRangeAtPosition(pos, reg);
-        if (linkRange) {
-            let filePaths = util.getFilePaths(doc.getText(linkRange), doc);
-            let workspaceFolder = vscode.workspace.getWorkspaceFolder(doc.uri);
-            if (filePaths.length > 0) {
-                let text: string = "";
-                for (let i in filePaths) {
-                    text += config.folderTip ? `\`${filePaths[i].name}\`` : '';
-                    text += ` [${workspaceFolder.name + filePaths[i].showPath}](${filePaths[i].fileUri})  \r`;
-                }
-                return new vscode.Hover(new vscode.MarkdownString(text));
+
+        if (!linkRange) return
+
+        let filePaths = util.getFilePaths(doc.getText(linkRange), doc);
+        let workspaceFolder = vscode.workspace.getWorkspaceFolder(doc.uri);
+        if (filePaths.length > 0) {
+            let text: string = "";
+            for (let i in filePaths) {
+                text += `\`${filePaths[i].name}\``;
+                text += ` [${workspaceFolder.name + filePaths[i].showPath}](${filePaths[i].fileUri})  \r`;
             }
-        }
-        return;
+            return new vscode.Hover(new vscode.MarkdownString(text));
+        };
     }
 }

--- a/src/providers/hoverProvider.ts
+++ b/src/providers/hoverProvider.ts
@@ -5,20 +5,21 @@ import * as util from '../util';
 
 export class HoverProvider implements vscode.HoverProvider {
     provideHover(doc: vscode.TextDocument, pos: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
-        let reg = /(?<=trans\(|__\(|@lang\()(['"])[^'"]*\1/;
+        let reg = /(?<=view\(|@include\(|@extends\(|@component\()(['"])[^'"]*\1/;
+        let config = vscode.workspace.getConfiguration('laravel_goto_view');
         let linkRange = doc.getWordRangeAtPosition(pos, reg);
-
-        if (!linkRange) return
-
-        let filePaths = util.getFilePaths(doc.getText(linkRange), doc);
-        let workspaceFolder = vscode.workspace.getWorkspaceFolder(doc.uri);
-        if (filePaths.length > 0) {
-            let text: string = "";
-            for (let i in filePaths) {
-                text += `\`${filePaths[i].name}\``;
-                text += ` [${workspaceFolder.name + filePaths[i].showPath}](${filePaths[i].fileUri})  \r`;
+        if (linkRange) {
+            let filePaths = util.getFilePaths(doc.getText(linkRange), doc);
+            let workspaceFolder = vscode.workspace.getWorkspaceFolder(doc.uri);
+            if (filePaths.length > 0) {
+                let text: string = "";
+                for (let i in filePaths) {
+                    text += config.folderTip ? `\`${filePaths[i].name}\`` : '';
+                    text += ` [${workspaceFolder.name + filePaths[i].showPath}](${filePaths[i].fileUri})  \r`;
+                }
+                return new vscode.Hover(new vscode.MarkdownString(text));
             }
-            return new vscode.Hover(new vscode.MarkdownString(text));
-        };
+        }
+        return;
     }
 }

--- a/src/providers/linkProvider.ts
+++ b/src/providers/linkProvider.ts
@@ -6,27 +6,26 @@ import * as util from '../util';
 export class LinkProvider implements vscode.DocumentLinkProvider {
     public provideDocumentLinks(doc: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentLink[]> {
         let documentLinks = [];
-        let config = vscode.workspace.getConfiguration('laravel_goto_view');
         let index = 0;
-        let reg = /(?<=view\(|@include\(|@extends\(|@component\()(['"])[^'"]*\1/g;
-        if (config.quickJump) {
-            while (index < doc.lineCount) {
-                let line = doc.lineAt(index);
-                let result = line.text.match(reg);
-                if (result != null) {
-                    for (let item of result) {
-                        let file = util.getFilePath(item, doc);
-                        if (file != null) {
-                            let start = new vscode.Position(line.lineNumber, line.text.indexOf(item));
-                            let end = start.translate(0, item.length);
-                            let documentlink = new vscode.DocumentLink(new vscode.Range(start, end), file.fileUri);
-                            documentLinks.push(documentlink);
-                        };
-                    }
+        let reg = /(?<=trans\(|__\(|@lang\()(['"])[^'"]*\1/g;
+
+        while (index < doc.lineCount) {
+            let line = doc.lineAt(index);
+            let result = line.text.match(reg);
+            if (result != null) {
+                for (let item of result) {
+                    let file = util.getFilePath(item, doc);
+                    if (file != null) {
+                        let start = new vscode.Position(line.lineNumber, line.text.indexOf(item));
+                        let end = start.translate(0, item.length);
+                        let documentlink = new vscode.DocumentLink(new vscode.Range(start, end), file.fileUri);
+                        documentLinks.push(documentlink);
+                    };
                 }
-                index++;
             }
+            index++;
         }
+
         return documentLinks;
     }
 }

--- a/src/providers/linkProvider.ts
+++ b/src/providers/linkProvider.ts
@@ -6,26 +6,27 @@ import * as util from '../util';
 export class LinkProvider implements vscode.DocumentLinkProvider {
     public provideDocumentLinks(doc: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentLink[]> {
         let documentLinks = [];
+        let config = vscode.workspace.getConfiguration('laravel_goto_view');
         let index = 0;
-        let reg = /(?<=trans\(|__\(|@lang\()(['"])[^'"]*\1/g;
-
-        while (index < doc.lineCount) {
-            let line = doc.lineAt(index);
-            let result = line.text.match(reg);
-            if (result != null) {
-                for (let item of result) {
-                    let file = util.getFilePath(item, doc);
-                    if (file != null) {
-                        let start = new vscode.Position(line.lineNumber, line.text.indexOf(item));
-                        let end = start.translate(0, item.length);
-                        let documentlink = new vscode.DocumentLink(new vscode.Range(start, end), file.fileUri);
-                        documentLinks.push(documentlink);
-                    };
+        let reg = /(?<=view\(|@include\(|@extends\(|@component\()(['"])[^'"]*\1/g;
+        if (config.quickJump) {
+            while (index < doc.lineCount) {
+                let line = doc.lineAt(index);
+                let result = line.text.match(reg);
+                if (result != null) {
+                    for (let item of result) {
+                        let file = util.getFilePath(item, doc);
+                        if (file != null) {
+                            let start = new vscode.Position(line.lineNumber, line.text.indexOf(item));
+                            let end = start.translate(0, item.length);
+                            let documentlink = new vscode.DocumentLink(new vscode.Range(start, end), file.fileUri);
+                            documentLinks.push(documentlink);
+                        };
+                    }
                 }
+                index++;
             }
-            index++;
         }
-
         return documentLinks;
     }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,6 @@
 
 import { workspace, TextDocument, Uri } from 'vscode';
 import * as fs from "fs";
-import * as path from "path";
 
 export function getFilePath(text: string, document: TextDocument) {
     let paths = getFilePaths(text, document);
@@ -10,62 +9,34 @@ export function getFilePath(text: string, document: TextDocument) {
 }
 
 export function getFilePaths(text: string, document: TextDocument) {
-    let paths = scanViewPaths(document);
-    let config = workspace.getConfiguration('laravel_goto_view');
+    let path = scanLangPaths(document);
+    let extension = '.php';
     let workspaceFolder = workspace.getWorkspaceFolder(document.uri).uri.fsPath;
+
     text = text.replace(/\"|\'/g, '');
     let result = [];
-    
-    if (text.indexOf("::") != -1) {
-        let info = text.split('::');
-        let folder = info[0]
-        let files = info[1].split('.').join('/')
+    let split = text.split('.');
 
-        for (let item in paths) {
-            for (let extension in config.extensions) {
-                let showPath = paths[item] + `/${folder}/${files}` + config.extensions[extension];
-                let filePath = workspaceFolder + showPath;
-                if (fs.existsSync(filePath)) {
-                    result.push({
-                        "name": item,
-                        "showPath": showPath,
-                        "fileUri": Uri.file(filePath)
-                    });
-                }
-            }
-        }
-    } else {
-        for (let item in paths) {
-            for (let extension in config.extensions) {
-                let showPath = paths[item] + "/" + text.replace(/\./g, '/') + config.extensions[extension];
-                let filePath = workspaceFolder + showPath;
-                if (fs.existsSync(filePath)) {
-                    result.push({
-                        "name": item,
-                        "showPath": showPath,
-                        "fileUri": Uri.file(filePath)
-                    });
-                }
-            }
+    while (split.length) {
+        let join = split.length > 0 ? split.join('/') : `${split}/`;
+        let showPath = `${path}/${join}${extension}`;
+        let filePath = workspaceFolder + showPath;
+
+        if (fs.existsSync(filePath)) {
+            result.push({
+                "name": 'path',
+                "showPath": showPath,
+                "fileUri": Uri.file(filePath)
+            });
+            split = []
+        } else {
+            split.pop();
         }
     }
 
     return result;
 }
 
-export function scanViewPaths(document: TextDocument) {
-    let configFolders = workspace.getConfiguration('laravel_goto_view.folders');
-    let folders = {};
-    Object.assign(folders, configFolders);
-    let workspaceFolder = workspace.getWorkspaceFolder(document.uri).uri.fsPath;
-    let modulePath = path.join(workspaceFolder, 'Modules');
-    if (fs.existsSync(modulePath)) {
-        fs.readdirSync(modulePath).forEach(element => {
-            let file = path.join(modulePath, element);
-            if (fs.statSync(file).isDirectory()) {
-                folders[element.toLocaleLowerCase()] = "/Modules/" + element + "/resources/views";
-            }
-        });
-    }
-    return folders;
+export function scanLangPaths(document: TextDocument) {
+    return workspace.getConfiguration('laravel_goto_lang.folders').default;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,17 +15,23 @@ export function getFilePaths(text: string, document: TextDocument) {
     let workspaceFolder = workspace.getWorkspaceFolder(document.uri).uri.fsPath;
     text = text.replace(/\"|\'/g, '');
     let result = [];
+    
     if (text.indexOf("::") != -1) {
         let info = text.split('::');
-        for (let extension in config.extensions) {
-            let showPath = paths[info[0]] + "/" + info[1].replace(/\./g, '/') + config.extensions[extension];
-            let filePath = workspaceFolder + showPath;
-            if (fs.existsSync(filePath)) {
-                result.push({
-                    "name": info[0],
-                    "showPath": showPath,
-                    "fileUri": Uri.file(filePath)
-                });
+        let folder = info[0]
+        let files = info[1].split('.').join('/')
+
+        for (let item in paths) {
+            for (let extension in config.extensions) {
+                let showPath = paths[item] + `/${folder}/${files}` + config.extensions[extension];
+                let filePath = workspaceFolder + showPath;
+                if (fs.existsSync(filePath)) {
+                    result.push({
+                        "name": item,
+                        "showPath": showPath,
+                        "fileUri": Uri.file(filePath)
+                    });
+                }
             }
         }
     } else {


### PR DESCRIPTION
the package wasnt working with paths in vendor because we dont search for all paths that have similarity with the file path we want, 
instead we depend on the pre-declared path either by user or in 'package.json`, 

so now the code is slightly changed to search in all the paths defined & added the vendor folder to the package default paths array.

still `scanViewPaths()` needs to be cleanedup though

**PS**
ignore the tooooo many changes, i didnt sleep for long and pushing changes from the browser