### PR TITLE
Add support for View::make() facade

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
                 },
                 "laravel_goto_view.regex": {
                     "type": "string",
-                    "default": "(?<=view\\(['\"]|@include\\(['\"]|@extends\\(['\"]|@component\\(['\"]|Inertia::render\\(['\"]|\\<)(\\<x-|\\<livewire:|[^'\" \\/>]+)",
+                    "default": "(?<=view\\(['\"]|View::make\\(['\"]|@include\\(['\"]|@extends\\(['\"]|@component\\(['\"]|Inertia::render\\(['\"]|\\<)(\\<x-|\\<livewire:|[^'\" \\/>]+)",
                     "description": "Custom regex for matching strings"
                 },
                 "laravel_goto_view.folders": {


### PR DESCRIPTION
Adds support for the `Illuminate\Support\Facades\View` facade, especifically the `make()` method of said facade

Before:
![image](https://user-images.githubusercontent.com/13445515/148256657-0ffaf62a-7951-418b-99db-47c31dfd8502.png)

After:
![image](https://user-images.githubusercontent.com/13445515/148256835-fae46525-da51-4e40-8a90-4910f07866c9.png)
