### PR TITLE
added assertViewIs to the default regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
                 },
                 "laravel_goto_view.regex": {
                     "type": "string",
-                    "default": "(?<=view\\(['\"]|markdown\\(['\"]|\\(view:.['\"]|View::make\\(['\"]|@include\\(['\"]|@extends\\(['\"]|@component\\(['\"]|Inertia::(?:render|modal)\\(['\"]|\\(component:.['\"]|<)(?:x-|livewire:|[^'\"\\s/>]+(?:\\/[^'\"\\s/>]+)*)",
+                    "default": "(?<=view\\(['\"]|markdown\\(['\"]|assertViewIs\\(['\"]|\\(view:.['\"]|View::make\\(['\"]|@include\\(['\"]|@extends\\(['\"]|@component\\(['\"]|Inertia::(?:render|modal)\\(['\"]|\\(component:.['\"]|<)(?:x-|livewire:|[^'\"\\s/>]+(?:\\/[^'\"\\s/>]+)*)",
                     "description": "Custom regex for matching strings"
                 },
                 "laravel_goto_view.folders": {


### PR DESCRIPTION
The `assertViewIs` function references views as it's first parameter. Added this as a default so that that users no longer need to add it to their settings.json config themselves.